### PR TITLE
use localStorage.remote for remote

### DIFF
--- a/modules/sbot.js
+++ b/modules/sbot.js
@@ -101,14 +101,9 @@ module.exports = {
       console.log('CONFIG', config)
 
       config.manifest = require('../manifest.json')
+      config.remote = localStorage.remote
 
-      createClient(keys, config/*{
-        manifest: require('../manifest.json'),
-        remote: localStorage.remote,
-        caps: config.caps,
-        
-        host: config.host, port: config.post, key: config.keys.id
-      }*/, function (err, _sbot) {
+      createClient(keys, config, function (err, _sbot) {
         if(err) {
           console.log(err.stack)
           return notify(err)


### PR DESCRIPTION
This pull request fixes the Patchless lite client. It turns out `localStorage.remote` got commented out, and that was causing the lite client to not work.

The sbot null error was also fixed in 138ef3af207e338ec2043c3eea34063e02b1e393, but that wasn't the primary issue.